### PR TITLE
better layer configuration output

### DIFF
--- a/mlp/converters/neon2iosmlp.py
+++ b/mlp/converters/neon2iosmlp.py
@@ -41,7 +41,7 @@ def convert(neon_model_path, output_filename):
 
 def write_layers_to_file(layers, output_filename):
     """Write the layer configuration of a model to the output file."""
-    
+
     with open(output_filename, 'w') as f:
         data = " ".join(str(e) for e in layers)
         f.write(data)

--- a/mlp/training/acceleration_dataset.py
+++ b/mlp/training/acceleration_dataset.py
@@ -17,7 +17,7 @@ class AccelerationDataset(object):
     TRAIN_RATIO = 0.8
 
     # This defines the range of the values the accelerometer measures
-    Feature_Range = 8000
+    Feature_Range = 4.0
     Feature_Mean = 0
     
     Target_Feature_Length = 400


### PR DESCRIPTION
This PR allows the model to write out not just the number of units, but also the activation functions. So, the output in ``x_layers.txt`` is now

```
1200 id 500 relu 200 relu 3 logistic
```

The matching muvr-ios PR https://github.com/muvr/muvr-ios/pull/92 implements the load counterpart.