### PR TITLE
fixed label file writer

### DIFF
--- a/mlp/training/acceleration_dataset.py
+++ b/mlp/training/acceleration_dataset.py
@@ -33,14 +33,10 @@ class AccelerationDataset(object):
         """Store the label <--> id mapping to file. The id is defined by the line number."""
         labels = self.ordered_labels()
 
-        f = open(filename, 'wb')
-
-        for label in labels:
-            f.write("%s\n" % label)
-        f.close()
+        with open(filename, 'wb') as f:
+            f.write("\n".join(labels))
 
     def generate_examples(self, examples):
-
         return examples
     
     def prepare_dataset(self, dataset, add_generated_examples):


### PR DESCRIPTION
Old output added a newline after the last label, which was wrongly read by the ios-app